### PR TITLE
Version 1.2 / 2024-01-22

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,14 @@
 # KineticCafe/actions Changelog
 
+## 1.2 / 2024-01-22
+
+- Enhance `KineticCafe/actions/dependabot-automerge` to allow specification
+  of the type of merge to run. Found because we have repositories configured not
+  to allow merge commits.
+
+- Fix an issue with `KineticCafe/actions/resolve-ref` for non-PR resolution
+  where the output on error was being captured as the `TARGET_SHA`.
+
 ## 1.1 / 2024-01-13
 
 - Initial release of `KineticCafe/actions/resolve-ref`. This is the extraction

--- a/dependabot-automerge/README.md
+++ b/dependabot-automerge/README.md
@@ -3,33 +3,6 @@
 A simple composite action to simplify the enabling of auto-merge of Dependabot
 PRs.
 
-You probably don't need this action. There is a little bit of logic applied, but
-this is roughly the same as:
-
-```yaml
-jobs:
-  dependabot-automerge:
-    permissions:
-      contents: write
-      pull-request: write
-
-    runs-on: ubuntu-latest
-
-    if: github.event_name == 'pull_request' && github.actor == 'dependabot[bot]'
-
-    - id: metadata
-      uses: dependabot/fetch-metadata@v1
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-
-    - if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
-      run: gh pr merge --auto --merge "$PR_URL"
-      shell: bash
-      env:
-        PR_URL: ${{ github.event.pull_request.html_url }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-```
-
 ## Example Usage
 
 ```yaml
@@ -50,6 +23,7 @@ jobs:
       - uses: KineticCafe/actions/dependabot-automerge@v1.1
         with:
           update-type: minor
+          merge-type: rebase
 ```
 
 ## Inputs
@@ -59,6 +33,9 @@ jobs:
 
   Default: `${{ github.token }}`
 
-- `update-type`: The highest level of update that can be auto-merged. The
-  default value is `patch`, and supported values are `major`, `minor`, and
-  `patch`. It is not recommended to specify `major`.
+- `update-type`: The highest level of update that can be automatically merged.
+  The default value is `patch`; supported values are `major`, `minor`, and
+  `patch`. Automatic merge for `major` is not recommended.
+
+- `merge-type`: The type of merge to be applied. Defaults to `merge`; supported
+  values are `merge`, `rebase`, and `squash`.

--- a/dependabot-automerge/action.yml
+++ b/dependabot-automerge/action.yml
@@ -25,12 +25,17 @@ inputs:
     default: ${{ github.token }}
   update-type:
     description: |
-      The highest level of update that can be automerged. The default value is
-      `patch`, and supported values are `major`, `minor`, and `patch`. It is not
-      recommended to specify `major`.
+      The highest level of update that can be automatically merged. The default
+      value is `patch`; supported values are `major`, `minor`, and `patch`.
+      Automatic merge for `major` is not recommended.
     required: false
     default: patch
-
+  merge-type:
+    description: |
+      The type of merge to be applied. Defaults to `merge`; supported values
+      are `merge`, `rebase`, and `squash`.
+    required: false
+    default: merge
 runs:
   using: 'composite'
   steps:
@@ -52,11 +57,21 @@ runs:
         (github.event_name == 'pull_request' || github.event_name == 'pull_request_target')
         && github.actor == 'dependabot[bot]'
         && steps.metadata.outputs.update-type == env.UPDATE_TYPE
-      run: gh pr merge --auto --merge "$PR_URL"
+      run: |
+        declare merge_flag
+
+        case "${MERGE_TYPE}" in
+        merge) merge_flag=--merge ;;
+        rebase) merge_flag=--rebase ;;
+        squash) merge_flag=--squash ;;
+        esac
+
+        gh pr merge --auto "${merge_flag}" "${PR_URL}"
       shell: bash
       env:
         PR_URL: ${{ github.event.pull_request.html_url }}
         GITHUB_TOKEN: ${{ inputs.repo-token }}
+        MERGE_TYPE: ${{ inputs.merge-type || 'merge' }}
 
 branding:
   icon: check-circle


### PR DESCRIPTION
- Enhance `KineticCafe/actions/dependabot-automerge` to allow specification
  of the type of merge to run. Found because we have repositories configured not
  to allow merge commits.

- Fix an issue with `KineticCafe/actions/resolve-ref` for non-PR resolution
  where the output on error was being captured as the `TARGET_SHA`.

