### PR TITLE
Upgrade `dependabot-automerge` dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,12 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: monthly
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /dependabot-automerge
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /resolve-ref
+    schedule:
+      interval: weekly

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,13 @@
 # KineticCafe/actions Changelog
 
+## 2.0 / 2024-10-01
+
+- Upgrade `KineticCafe/actions/dependabot-automerge` dependencies. This includes
+  a dependency that now uses Node 20 (as Node 16 is deprecated on Actions), so
+  this is considered a breaking change.
+
+There are no changes to other composite actions.
+
 ## 1.4 / 2024-03-15
 
 - Added `KineticCafe/actions/extract-changelog` for a simple changelog
@@ -18,9 +26,9 @@ accessed via `@v1.2` or `@v1.3`.
 
 ## 1.2 / 2024-01-22
 
-- Enhance `KineticCafe/actions/dependabot-automerge` to allow specification
-  of the type of merge to run. Found because we have repositories configured not
-  to allow merge commits.
+- Enhance `KineticCafe/actions/dependabot-automerge` to allow specification of
+  the type of merge to run. Found because we have repositories configured not to
+  allow merge commits.
 
 - Fix an issue with `KineticCafe/actions/resolve-ref` for non-PR resolution
   where the output on error was being captured as the `TARGET_SHA`.
@@ -29,7 +37,7 @@ accessed via `@v1.2` or `@v1.3`.
 
 - Initial release of `KineticCafe/actions/resolve-ref`. This is the extraction
   of a complex reused script used in multiple repositories in
-  [KineticCommerce][].
+  [KineticCommerce][KineticCommerce].
 
 There are no changes to `KineticCafe/actions/dependabot-automerge`. It can be
 accessed via `@v1.0` or `@v1.1`.
@@ -38,7 +46,7 @@ accessed via `@v1.0` or `@v1.1`.
 
 - Initial release of `KineticCafe/actions/dependabot-automerge`. This is the
   extraction of a common workflow used across repositories in both
-  [KineticCafe][] and [KineticCommerce][].
+  [KineticCafe][KineticCafe] and [KineticCommerce][KineticCommerce].
 
 [KineticCafe]: https://github.com/KineticCafe
 [KineticCommerce]: https://github.com/KineticCommerce

--- a/dependabot-automerge/action.yml
+++ b/dependabot-automerge/action.yml
@@ -14,28 +14,29 @@
 
 name: Enable Automerge for Dependabot
 description: |
-  Enables Automerge for Dependabot PRs
-author: 'KineticCafe'
+  Enables GitHub Automerge for Dependabot PRs
+author: KineticCafe
+
 inputs:
   repo-token:
     description: |
-      The GitHub token for this action. Requires `pull-requests: write`
-      permission.
+      The GitHub token for this action. Requires `pull-requests: write` permission.
     required: true
     default: ${{ github.token }}
   update-type:
     description: |
-      The highest level of update that can be automatically merged. The default
-      value is `patch`; supported values are `major`, `minor`, and `patch`.
-      Automatic merge for `major` is not recommended.
+      The highest level of update that can be automatically merged. The default value is
+      `patch`; supported values are `major`, `minor`, and `patch`. Automatic merge for
+      `major` is not recommended.
     required: false
     default: patch
   merge-type:
     description: |
-      The type of merge to be applied. Defaults to `merge`; supported values
-      are `merge`, `rebase`, and `squash`.
+      The type of merge to be applied. Defaults to `merge`; supported values are `merge`,
+      `rebase`, and `squash`.
     required: false
     default: merge
+
 runs:
   using: 'composite'
   steps:
@@ -49,7 +50,7 @@ runs:
         (github.event_name == 'pull_request' || github.event_name == 'pull_request_target')
         && github.actor == 'dependabot[bot]'
       id: metadata
-      uses: dependabot/fetch-metadata@v1
+      uses: dependabot/fetch-metadata@v2
       with:
         github-token: ${{ inputs.repo-token }}
 


### PR DESCRIPTION
This includes a dependency that now uses Node 20 (as Node 16 is
deprecated on Actions), so this is considered a breaking change.
